### PR TITLE
feat: add swipe inspect mode toggle

### DIFF
--- a/src/streamlit_swipecards/frontend/style.css
+++ b/src/streamlit_swipecards/frontend/style.css
@@ -208,6 +208,31 @@ body {
   opacity: 0.8;
 }
 
+/* Mode toggle styles */
+.mode-toggle {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.mode-btn {
+  padding: 4px 12px;
+  border-radius: 20px;
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 13px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.mode-btn.active {
+  background: var(--button-gradient);
+  color: #fff;
+  border: none;
+}
+
 .action-btn {
   width: 60px;
   height: 60px;
@@ -222,6 +247,24 @@ body {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   color: white;
   box-shadow: 0 4px 12px var(--shadow-color);
+}
+
+/* Disable interactions when in inspect mode */
+.swipe-container.inspect-mode .swipe-card {
+  cursor: default;
+}
+
+.swipe-container.inspect-mode .action-btn {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.swipe-container.swipe-mode .ag-grid-container {
+  pointer-events: none;
+}
+
+.swipe-container.inspect-mode .ag-grid-container {
+  pointer-events: auto;
 }
 
 .action-btn:hover {


### PR DESCRIPTION
## Summary
- add swipe/inspect mode toggle with Streamlit styling
- disable table movement during swiping and lock cards during inspection

## Testing
- `python -m py_compile src/streamlit_swipecards/__init__.py example.py`


------
https://chatgpt.com/codex/tasks/task_e_688ca59d32f483228334b6d3a1d9a268